### PR TITLE
Fix for Resources folders were not found while running tests .

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   dependencies {
     //decreased version from 1.2.3 to 1.1.0 due to broken lint support
     //see https://code.google.com/p/android/issues/detail?id=174808
-    classpath 'com.android.tools.build:gradle:1.1.0'
+    classpath 'com.android.tools.build:gradle:2.2.3'
 
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun May 31 09:59:05 CEST 2015
+#Fri Feb 03 12:42:45 IST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/lintrules/build.gradle
+++ b/lintrules/build.gradle
@@ -16,3 +16,8 @@ jar {
     attributes 'Lint-Registry': 'de.droidcon.workshop.lint.CustomIssueRegistry'
   }
 }
+task copyTestResources(type: Copy) {
+  from "${projectDir}/src/test/resources"
+  into "${buildDir}/classes/test"
+}
+processTestResources.dependsOn copyTestResources


### PR DESCRIPTION
While running HelloWorldDetectorTest the classLoader.getResource(relativePath) in getFiles() in TestLintClient was not able to find the resources as the the lookup happened in build/classes folder. So added a gradle task to copy test/resources folder content to build/classes/test/resources to make the relative paths work.  

Refer to:
http://stackoverflow.com/questions/27046642/access-file-in-junit-test-in-gradle-environment
https://code.google.com/p/android/issues/detail?id=64887